### PR TITLE
Deactivate destructive setup commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,11 +97,12 @@ instructions. You only need to execute them once to setup your environment:
 
         (my-repository-venv)$ pip install --editable .[all]
 
-4.  Execute the Invenio initial bootstrap code in the virtual environment
+4.  Execute the Invenio initial bootstrap and setup code in the virtual environment
 
     .. code-block::
 
         (my-repository-venv)$ ./scripts/bootstrap
+        (my-repository-venv)$ ./scripts/setup
 
 5.  Start the containers for the services
 
@@ -193,3 +194,8 @@ To make the change immediate on a live machine:
     .. code-block::
 
         sysctl -w vm.max_map_count=262144
+
+# TODO: Remove the following by having the deployment script do it for us
+On initial deployment, run the setup script:
+
+    (virtualenv)$ ./scripts/setup

--- a/scripts/setup
+++ b/scripts/setup
@@ -10,12 +10,13 @@ set -e
 
 # Clean redis
 invenio shell --no-term-title -c "import redis; redis.StrictRedis.from_url(app.config['CACHE_REDIS_URL']).flushall(); print('Cache cleared')"
-invenio db destroy --yes-i-know
+# Commented out the below destructive actions for now
+# invenio db destroy --yes-i-know
 invenio db init create
-invenio index destroy --force --yes-i-know
+# invenio index destroy --force --yes-i-know
 invenio index init --force
-invenio index queue init purge
+# invenio index queue init purge
 
-# Create admin role to rectict access
+# Create admin role to restrict access
 invenio roles create admin
 invenio access allow superuser-access role admin


### PR DESCRIPTION
./scripts/setup must be run once in the deployed environment
to setup tables and indices.

Documents this in README