### PR TITLE
Make the footer sticky

### DIFF
--- a/cd2h_repo_project/config.py
+++ b/cd2h_repo_project/config.py
@@ -65,9 +65,9 @@ SETTINGS_TEMPLATE = 'invenio_theme/page_settings.html'
 # Theme configuration
 # ===================
 #: Site name
-THEME_SITENAME = _('CD2H Repo Project')
+THEME_SITENAME = _('Next Generation Repository')
 #: Frontpage title.
-THEME_FRONTPAGE_TITLE = _('CD2H Repo Project')
+THEME_FRONTPAGE_TITLE = _('Next Generation Repository')
 # THEME_HEADER_LOGIN_TEMPLATE = 'invenio_theme/header_login.html'
 
 # Email configuration

--- a/cd2h_repo_project/modules/theme/static/scss/body.scss
+++ b/cd2h_repo_project/modules/theme/static/scss/body.scss
@@ -3,6 +3,6 @@ body {
   color: #54585A;
   font-family: Calibri,Helvetica,Arial,sans-serif;
   font-size: 16px;
-  margin:0;
+  margin: 0 0 300px 0;
   padding:0 !important
 }

--- a/cd2h_repo_project/modules/theme/static/scss/footer.scss
+++ b/cd2h_repo_project/modules/theme/static/scss/footer.scss
@@ -10,6 +10,9 @@
   letter-spacing: 0.4px;
   line-height: 1.8em;
   word-wrap: break-word;
+  position: absolute;
+  bottom: 0;
+  height: 300px;
 
   .container .row {
     padding-top: 2.16667%;

--- a/cd2h_repo_project/modules/theme/static/scss/styles.scss
+++ b/cd2h_repo_project/modules/theme/static/scss/styles.scss
@@ -8,6 +8,11 @@ $fa-font-path: "/static/node_modules/font-awesome/fonts";
 @import "../node_modules/bootstrap-sass/assets/stylesheets/_bootstrap";
 @import "../node_modules/font-awesome/scss/font-awesome";
 
+html {
+  position: relative;
+  min-height: 100%;
+}
+
 // @import "type";
 // @import "navbar";
 @import "body";

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ install_requires = [
     #       to invenio-deposit
     'SQLAlchemy-Continuum==1.3.4',
     'marshmallow==2.15.5',
+    'invenio-accounts>=1.0.2'
 ]
 
 packages = find_packages()


### PR DESCRIPTION
This ensures that if there is not enough content on the page, the footer should "stick" to the bottom of the page rather than being displayed directly after the content (mid-page).