### PR TITLE
Enable production deployment with pipenv [more]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN pip install --upgrade \
     pipenv==2018.11.14
 
 # Copy uwsgi config files (will typically not bust the cache)
+# This only copies the files and NOT the directory itself
 RUN mkdir -p ${INVENIO_INSTANCE_PATH}
 COPY docker/uwsgi/ ${INVENIO_INSTANCE_PATH}
 

--- a/deployment/ansible/playbook.yml
+++ b/deployment/ansible/playbook.yml
@@ -52,16 +52,28 @@
       lineinfile:
         path: /etc/sysctl.conf
         line: vm.max_map_count=262144
+      become: yes
+
+    # TODO: Automate file generation?
+    - name: custom .env file exists
+      stat:
+        path: /home/deploy/cd2h-repo-project/.env
+      register: status
+    - name: custom .env file exists failed
+      fail:
+        msg: "You need to manually provide the cd2h-repo-project/.env file!"
+      when: status.stat.exists == False
 
     # Note that this task is long and will always be run right now
+    # TODO: Use prebuilt image from registry
     - name: containers are up and running
-      command: docker-compose --file docker-compose.prod.yml
+      command: docker-compose --file docker-compose.prod.yml up --build --detach
       args:
         chdir: cd2h-repo-project
 
     - name: one-time scripts/setup was run
       # TODO: have `./scripts/setup` be idempotent
-      shell: docker exec cd2h-repo-project_web-ui_1 ./scripts/setup && touch setup_was_run.flag
+      shell: docker exec cd2h-repo-project_web-ui_1 pipenv run ./scripts/setup && touch setup_was_run.flag
       args:
         creates: setup_was_run.flag
       tags:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -64,7 +64,7 @@ services:
       file: docker-services.yml
       service: app
     restart: "always"
-    command: "celery worker -A invenio_app.celery --loglevel=INFO"
+    command: "pipenv run celery worker -A invenio_app.celery --loglevel=INFO"
     image: cd2h-repo-project-worker
     links:
       - cache

--- a/docker/uwsgi/uwsgi_rest.ini
+++ b/docker/uwsgi/uwsgi_rest.ini
@@ -14,3 +14,4 @@ processes = 2
 threads = 2
 mount = /api=invenio_app.wsgi_rest:application
 manage-script-name = true
+virtualenv = /opt/cd2h-repo-project/src/.venv

--- a/docker/uwsgi/uwsgi_ui.ini
+++ b/docker/uwsgi/uwsgi_ui.ini
@@ -13,3 +13,4 @@ master = true
 die-on-term = true
 processes = 2
 threads = 2
+virtualenv = /opt/cd2h-repo-project/src/.venv


### PR DESCRIPTION
- Use pipenv to run `scripts/setup` via ansible
- Run uwsgi with virtualenv configured in .ini
  but w/o `pipenv run`