### PR TITLE
Display file metadata + Download Files [more]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,7 @@ RUN pipenv run ./scripts/bootstrap
 # Set folder permissions
 RUN chgrp -R 0 ${WORKING_DIR} && \
     chmod -R g=u ${WORKING_DIR}
+# RUN chmod -R g=u ${WORKING_DIR}
 
 RUN useradd invenio --uid 1000 --gid 0 && \
     chown -R invenio:root ${WORKING_DIR}

--- a/cd2h_repo_project/config.py
+++ b/cd2h_repo_project/config.py
@@ -250,7 +250,13 @@ RECORDS_UI_ENDPOINTS = {
         'route': '/records/<pid_value>',
         'template': 'records/view.html',
         # 'record_class': ....
-    }
+    },
+    'recid_files': {
+        'pid_type': 'recid',
+        'route': '/records/<pid_value>/files/<path:filename>',
+        'view_imp': 'invenio_records_files.utils.file_download_ui',
+        'record_class': 'invenio_records_files.api:Record',
+    },
 }
 """Records UI for Records."""
 

--- a/cd2h_repo_project/modules/records/links.py
+++ b/cd2h_repo_project/modules/records/links.py
@@ -9,14 +9,22 @@ from invenio_deposit.links import \
     deposit_links_factory as _deposit_links_factory
 
 
-def deposit_links_api_factory(pid, record=None):
+def deposit_links_api_factory(pid, **kwargs):
     """
     Return, from the API applicaton, the useful URLs related to this record.
 
     Adapted from https://github.com/zenodo/zenodo
 
     Note: Zenodo separates this functionality between API and UI so we do too.
+    WARNING: **kwargs is necessary because Invenio does a backward
+             compatibility check solely based on presence of **kwargs
+             (invenio_records_rest/_compat.py). **kwargs indicates this is a
+             "new style" link factory.
+
+    :param pid: PersistentIdentifier of the record.
+    :param kwargs: Keyword arguments, key 'record' and value Record is required
     """
+    record = kwargs.get('record')
     links = _deposit_links_factory(pid)
 
     links['html'] = current_app.config['DEPOSIT_UI_ENDPOINT'].format(
@@ -35,14 +43,22 @@ def deposit_links_api_factory(pid, record=None):
     return links
 
 
-def deposit_links_ui_factory(pid, record=None):
+def deposit_links_ui_factory(pid, **kwargs):
     """
     Return, from the UI application, the useful URLs related to this record.
 
     Adapted from https://github.com/zenodo/zenodo
 
     Note: Zenodo separates this functionality between API and UI so we do too.
+    WARNING: **kwargs is necessary because Invenio does a backward
+             compatibility check solely based on presence of **kwargs
+             (invenio_records_rest/_compat.py). **kwargs indicates this is a
+             "new style" link factory.
+
+    :param pid: PersistentIdentifier of the record.
+    :param kwargs: Keyword arguments, key 'record' and value Record is required
     """
+    record = kwargs.get('record')
     base_API_url = current_app.config['DEPOSIT_RECORDS_API'].format(
         pid_value=pid.pid_value)
 

--- a/cd2h_repo_project/modules/records/templates/records/files_list.html
+++ b/cd2h_repo_project/modules/records/templates/records/files_list.html
@@ -1,0 +1,30 @@
+{% if record._files %}
+<div class="panel panel-{{state}}" id="files">
+  <div class="collapse in" id="collapseTwo">
+    <table class="table table-striped" >
+      <thead>
+        <tr>
+          <th>Filename</th>
+          <th>Size</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+      {%- for file in record._files|sort(attribute='key') -%}
+      {%- set file_url = url_for('invenio_records_ui.recid_files', pid_value=pid.pid_value, filename=file.key, download=1) %}
+        <tr>
+          <td><a class="filename" href="{{file_url}}">{{ file.key }}</a></td>
+          <td class="nowrap">{{ file.size|filesizeformat }}</td>
+          <td class="nowrap"><span class="pull-right"><a class="btn btn-xs btn-default" href="{{file_url}}"><i class="fa fa-download"></i> Download</a></span></td>
+        </tr>
+      {%- endfor -%}
+        <tr>
+          <th>Total Size</th>
+          <td class="nowrap">{{record._files|sum(attribute='size')|filesizeformat}}</td>
+          <td class="nowrap"></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endif %}

--- a/cd2h_repo_project/modules/records/templates/records/view.html
+++ b/cd2h_repo_project/modules/records/templates/records/view.html
@@ -68,13 +68,7 @@
     <div class="row">
       <div id="invenio-records">
         <div class="col-md-4">
-          {% if record._files %}
-          <ul>
-            {% for file in record._files %}
-              <li>{{ file.key }} ({{file.size | filesizeformat}})</li>
-            {% endfor %}
-          </ul>
-          {% endif %}
+          {%- include "records/files_list.html" %}
 
           <br>
 

--- a/cd2h_repo_project/modules/records/views.py
+++ b/cd2h_repo_project/modules/records/views.py
@@ -72,7 +72,7 @@ def license_value_to_name(value):
 @blueprint.app_template_filter('get_links')
 def get_links(pid, record):
     """Return dictionary of related links."""
-    return deposit_links_ui_factory(pid, record)
+    return deposit_links_ui_factory(pid, record=record)
 
 
 def edit_view_method(pid, record, template=None):

--- a/tests/api/records/test_api.py
+++ b/tests/api/records/test_api.py
@@ -1,10 +1,8 @@
-from unittest import TestCase
-
 from invenio_files_rest.models import Bucket
 from invenio_records.models import RecordMetadata
 from invenio_records_files.models import RecordsBuckets
 
-from cd2h_repo_project.modules.records.api import Deposit
+from cd2h_repo_project.modules.records.api import Deposit, RecordType
 
 
 def test_deposit_create_creates_recordsbuckets(locations):
@@ -31,17 +29,19 @@ def test_deposit_create_fills_data(locations):
 
 
 def test_deposit_publish(locations):
-    data = {}
-    deposit = Deposit.create(data)
+    deposit = Deposit.create({})
 
-    published_record = deposit.publish()
+    deposit_record = deposit.publish()
+    pid, published_record = deposit_record.fetch_published()
 
-    assert published_record['type'] == 'published'
+    assert deposit_record['type'] == RecordType.draft.value
+    assert published_record['type'] == RecordType.published.value
 
 
-def test_deposit_edit(create_record, db):
-    deposit = create_record()
+def test_deposit_edit(create_record):
+    deposit = create_record(published=False)
+    deposit.publish()  # to set deposit's _deposit.status = 'published'
 
     draft_record = deposit.edit()
 
-    assert draft_record['type'] == 'draft'
+    assert draft_record['type'] == RecordType.draft.value

--- a/tests/api/records/test_links.py
+++ b/tests/api/records/test_links.py
@@ -4,7 +4,7 @@ from cd2h_repo_project.modules.records.links import deposit_links_api_factory
 
 
 def test_deposit_links_api_factory_contains_bucket(app, create_record):
-    record = create_record()
+    record = create_record(published=False)
     expected_bucket_id = record['_buckets']['deposit']
 
     with patch(
@@ -17,7 +17,7 @@ def test_deposit_links_api_factory_contains_bucket(app, create_record):
 
 
 def test_deposit_links_api_factory_contains_html(app, create_record):
-    record = create_record()
+    record = create_record(published=False)
     expected_pid_value = record.pid.pid_value
 
     with patch(

--- a/tests/api/records/test_search.py
+++ b/tests/api/records/test_search.py
@@ -157,9 +157,10 @@ class TestDepositsSearch(object):
         print("****")
 
         print("Case: When published, only published record should be returned")
-        published_record = unpublished_record.publish()
+        unpublished_record.publish()
         db.session.commit()
         current_search.flush_and_refresh(index='*')
+        pid, published_record = unpublished_record.fetch_published()
 
         response = client.get('/deposits/')
 
@@ -168,8 +169,7 @@ class TestDepositsSearch(object):
 
         print("Case: When edited, draft and published record should be "
               "returned")
-        draft_record = unpublished_record
-        edited_record = draft_record.edit()  # edit() is always called on draft
+        edited_record = unpublished_record.edit()
         current_search.flush_and_refresh(index='*')
         db.session.commit()
 
@@ -188,9 +188,10 @@ class TestDepositsSearch(object):
         # Case: When edited record is published,
         print("Case: When re-published, only published record should be "
               "returned")
-        published_record = edited_record.publish()
+        edited_record.publish()
         db.session.commit()
         current_search.flush_and_refresh(index='*')
+        pid, published_record = edited_record.fetch_published()
 
         response = client.get('/deposits/')
 

--- a/tests/api/records/test_serializers.py
+++ b/tests/api/records/test_serializers.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+from invenio_pidstore.models import PersistentIdentifier
+
 from cd2h_repo_project.modules.records.marshmallow.json import (
     MetadataSchemaV1, RecordSchemaV1
 )
@@ -8,16 +10,24 @@ from cd2h_repo_project.modules.records.serializers import json_v1
 
 def test_json_v1_serializes_persistent_identifier(create_record):
     record = create_record()
+    pid = PersistentIdentifier.get(
+        record['_deposit']['pid']['type'],
+        record['_deposit']['pid']['value'],
+    )
 
-    serialized_record = json_v1.transform_record(record.pid, record)
+    serialized_record = json_v1.transform_record(pid, record)
 
-    assert serialized_record['id'] == record.pid.pid_value
+    assert serialized_record['id'] == record['_deposit']['pid']['value']
 
 
 def test_json_v1_serializes_dump_onlys(create_record):
     record = create_record()
+    pid = PersistentIdentifier.get(
+        record['_deposit']['pid']['type'],
+        record['_deposit']['pid']['value'],
+    )
 
-    serialized_record = json_v1.transform_record(record.pid, record)
+    serialized_record = json_v1.transform_record(pid, record)
 
     assert 'created' in serialized_record
     assert 'updated' in serialized_record
@@ -26,8 +36,12 @@ def test_json_v1_serializes_dump_onlys(create_record):
 
 def test_json_v1_serializes_metadata(create_record):
     record = create_record()
+    pid = PersistentIdentifier.get(
+        record['_deposit']['pid']['type'],
+        record['_deposit']['pid']['value'],
+    )
 
-    serialized_record = json_v1.transform_record(record.pid, record)
+    serialized_record = json_v1.transform_record(pid, record)
 
     required_keys = ['title', 'description', 'author', 'license']
     for key in required_keys:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,8 @@ def create_record(db, es_clear, locations, create_serialized_record):
             db.session.add(record.model)
 
         if published:
-            record = record.publish()
+            record.publish()
+            pid, record = record.fetch_published()
 
         # Flush to index and database
         current_search.flush_and_refresh(index='*')

--- a/tests/ui/records/test_links.py
+++ b/tests/ui/records/test_links.py
@@ -1,9 +1,11 @@
+from invenio_pidstore.models import PersistentIdentifier
+
 from cd2h_repo_project.modules.records.links import deposit_links_ui_factory
 
 
 def test_deposit_links_ui_factory_contains_all_links(app, create_record):
-    record = create_record()
-    expected_pid_value = record.pid.pid_value
+    record = create_record(published=False)
+    expected_pid_value = record['_deposit']['id']
     expected_bucket_id = record['_buckets']['deposit']
 
     links = deposit_links_ui_factory(record.pid, record=record)

--- a/tests/ui/test_views.py
+++ b/tests/ui/test_views.py
@@ -76,6 +76,10 @@ def test_record_page_shows_files(client, create_record):
     assert response.status_code == 200
     assert "fileA.png" in html_text
     assert "8.9 kB" in html_text
+    assert (
+        'href="/records/{}/files/fileA.png?download=1"'.format(record['id'])
+        in html_text
+    )
 
 
 def test_record_page_shows_edit_action_if_permitted(
@@ -91,7 +95,7 @@ def test_record_page_shows_edit_action_if_permitted(
     edit_links = html_tree.cssselect('a#edit-action')
 
     assert len(edit_links) == 1
-    pid_value = owned_record.pid.pid_value
+    pid_value = owned_record['_deposit']['id']
     assert edit_links[0].get('href') == '/records/{}/edit'.format(pid_value)
 
     response = client.get('/records/{}'.format(not_owned_record['id']))


### PR DESCRIPTION
- Closes #249; Closes #11
- Fix file upload by marking link factory as
  'new style'
- Show file metadata: name with extensions + size
- Allow download of uploaded files
- Refactor meaning of Deposit: API model truly
  only for draft records/initial deposits
- Update tests for the above