### PR TITLE
Fix merge conflict on 3rd publish (#267)

### DIFF
--- a/cd2h_repo_project/modules/doi/ext.py
+++ b/cd2h_repo_project/modules/doi/ext.py
@@ -7,6 +7,9 @@
 
 """Flask extension for DOI."""
 
+from cd2h_repo_project.modules.doi.triggers import doi_minting_trigger
+from cd2h_repo_project.modules.records.signals import menrva_record_published
+
 
 class DigitalObjectIdentifier(object):
     """Digital Object Identifier extension."""
@@ -19,3 +22,4 @@ class DigitalObjectIdentifier(object):
     def init_app(self, app):
         """Flask application initialization."""
         app.extensions['cd2h-doi'] = self
+        menrva_record_published.connect(doi_minting_trigger)

--- a/cd2h_repo_project/modules/doi/minters.py
+++ b/cd2h_repo_project/modules/doi/minters.py
@@ -4,7 +4,7 @@ from flask import current_app
 from invenio_pidstore.models import PersistentIdentifier, PIDStatus
 
 
-def mint_record_doi(record_uuid, data):
+def mint_doi_pid(record_uuid, data):
     """Mint doi PersistentIdentifier in an initial New state.
 
     Because DOIs are minted by an external service, we create a PID for

--- a/cd2h_repo_project/modules/doi/tasks.py
+++ b/cd2h_repo_project/modules/doi/tasks.py
@@ -5,13 +5,13 @@ from celery import shared_task
 from datacite.client import DataCiteMDSClient
 from datacite.errors import DataCiteError, HttpError
 from elasticsearch.exceptions import RequestError
-from flask import current_app, url_for
+from flask import current_app
 from invenio_db import db
 from invenio_indexer.api import RecordIndexer
-from invenio_pidstore.models import PersistentIdentifier, PIDStatus
-from invenio_records_files.api import Record
+from invenio_pidstore.models import PersistentIdentifier
 
 from cd2h_repo_project.modules.doi.serializers import datacite_v41
+from cd2h_repo_project.modules.records.api import Deposit
 from cd2h_repo_project.modules.records.links import (
     url_for_record_ui_recid_external
 )
@@ -33,18 +33,18 @@ def register_doi(recid_pid_value):
 
     This asynchronous task mints a DOI with the external service and
     stores it in the local doi PID. It will retry a `max_retries` number of
-    times if the service is down. It will not retry for other errors
-    (internal ones).
+    times.
 
     `default_retry_delay` is in seconds.
 
-    :param recid_pid_value: pid_value of recid PID for the target record.
+    :param recid_pid_value: pid_value of recid-PID for the target record.
                             Note that this pid_value is also the pid_value of
-                            the doi PID associated with the target record if
-                            it has not been DOI minted yet.
+                            the doi-PID associated with the target record if
+                            it has not been DOI-minted yet.
     """
     try:
-        pid, record = record_resolver.resolve(str(recid_pid_value))
+        recid_pid, record = record_resolver.resolve(str(recid_pid_value))
+        depid_pid, deposit = Deposit.fetch_deposit(record)
 
         doi_pid_value = record.get('doi') or recid_pid_value
         doi_pid = PersistentIdentifier.get(
@@ -62,26 +62,36 @@ def register_doi(recid_pid_value):
         serialized_record = datacite_v41.serialize(doi_pid, record)
         result = client.metadata_post(serialized_record)
 
-        # Associate landing page to DOI on DataCite if new
-        if doi_pid.status == PIDStatus.NEW:
+        # When minting for the first time, we need to associate the
+        # record's page to its metadata record on Datacite
+        if doi_pid.is_new():
             minted_doi = extract_doi(result)
             landing_url = url_for_record_ui_recid_external(recid_pid_value)
-            result = client.doi_post(minted_doi, landing_url)
+            client.doi_post(minted_doi, landing_url)
 
             # Update doi_pid
             doi_pid.pid_value = minted_doi
             doi_pid.register()
+
+            # Update deposit/record
+            deposit['doi'] = minted_doi
             record['doi'] = minted_doi
+            deposit.commit()
             record.commit()
-            # Necessary but unclear why: (TODO: Investigate)
-            # - call to record.commit() is done above and
-            # - tests don't need it
+            # The above only flushes (no db commit). The below is needed to
+            # persist the changes to the db.
             db.session.commit()
 
-            # Re-index record
+            # Re-index deposit/record
+            RecordIndexer().index(deposit)
             RecordIndexer().index(record)
 
     except (HttpError, DataCiteError) as e:
         register_doi.retry(exc=e)
     except RequestError:
         current_app.logger.exception('Could not index {}.'.format(record))
+    except Exception as e:
+        current_app.logger.exception(
+            'Exception in register_doi for recid_pid_value: {}. Retrying...'
+            .format(recid_pid_value))
+        register_doi.retry(exc=e)

--- a/cd2h_repo_project/modules/doi/triggers.py
+++ b/cd2h_repo_project/modules/doi/triggers.py
@@ -1,0 +1,14 @@
+"""Signal listeners."""
+
+from flask import current_app
+
+from .tasks import register_doi
+
+
+def doi_minting_trigger(recid_pid_value):
+    """Triggers doi minting.
+
+    :param recid_pid_value: record's PID value.
+    """
+    if current_app.config['DOI_REGISTER_SIGNALS']:
+        register_doi.delay(recid_pid_value)

--- a/cd2h_repo_project/modules/records/minters.py
+++ b/cd2h_repo_project/modules/records/minters.py
@@ -4,10 +4,10 @@ from flask import current_app
 from invenio_pidstore.models import PersistentIdentifier, PIDStatus
 from invenio_pidstore.providers.recordid import RecordIdProvider
 
-from cd2h_repo_project.modules.doi.minters import mint_record_doi
+from cd2h_repo_project.modules.doi.minters import mint_doi_pid
 
 
-def mint_record(record_uuid, data):
+def mint_pids_for_record(record_uuid, data):
     """Record PersistentIdentifiers minter.
 
     Mints:
@@ -18,12 +18,12 @@ def mint_record(record_uuid, data):
     :param data: Record object as dict (or dict-like).
     :returns: recid PersistentIdentifier
     """
-    pid = mint_record_recid(record_uuid, data)
-    mint_record_doi(record_uuid, data)
+    pid = mint_recid_pid(record_uuid, data)
+    mint_doi_pid(record_uuid, data)
     return pid
 
 
-def mint_record_recid(record_uuid, data):
+def mint_recid_pid(record_uuid, data):
     """Mint recid PersistentIdentifier.
 
     A recid PersistentIdentifier can only be minted if the Record has not

--- a/cd2h_repo_project/modules/records/permissions.py
+++ b/cd2h_repo_project/modules/records/permissions.py
@@ -7,10 +7,9 @@ from invenio_access import Permission
 from invenio_deposit.scopes import write_scope
 from invenio_deposit.utils import check_oauth2_scope
 from invenio_files_rest.models import Bucket, MultipartObject, ObjectVersion
-from invenio_records.api import Record
-from invenio_records_files.api import FileObject
 from invenio_records_files.models import RecordsBuckets
 
+from cd2h_repo_project.modules.records.api import FileObject, Record
 from cd2h_repo_project.utils import get_identity
 
 # Need instances #

--- a/cd2h_repo_project/modules/records/resolvers.py
+++ b/cd2h_repo_project/modules/records/resolvers.py
@@ -1,9 +1,27 @@
 """CD2H Record resolver."""
 
 from invenio_pidstore.resolver import Resolver
-from invenio_records_files.api import Record
+
+from cd2h_repo_project.modules.records.api import Deposit, Record
 
 record_resolver = Resolver(
     pid_type='recid', object_type='rec', getter=Record.get_record
 )
-"""'recid'-PID resolver for published Records."""
+"""'recid'-PID resolver for published Records.
+
+.. code-block:: python
+
+    record = record_resolver.resolve(recid_pid_value)
+"""
+
+
+deposit_resolver = Resolver(
+    pid_type='depid', object_type='rec', getter=Deposit.get_record
+)
+"""'depid'-PID resolver for draft Records ie Deposits.
+
+.. code-block:: python
+
+    deposit = deposit_resolver.resolve(depid_pid_value)
+
+"""

--- a/cd2h_repo_project/modules/records/signals.py
+++ b/cd2h_repo_project/modules/records/signals.py
@@ -1,0 +1,25 @@
+"""Record module signals."""
+
+from blinker import Namespace
+
+_signals = Namespace()
+
+menrva_record_published = _signals.signal('menrva-record-published')
+"""Signal is sent after a deposit is published.
+
+When implementing the event listener, the record data can be retrieved from
+`sender`.
+
+Example event listener (subscriber) implementation:
+
+.. code-block:: python
+
+    def listener(sender, *args, **kwargs):
+        record = get_record_from_sender(sender)
+        # do something with the record
+
+    from cd2h_repo_project.modules.records.signals import (
+        menrva_record_published
+    )
+    menrva_record_published.connect(listener)
+"""

--- a/setup.py
+++ b/setup.py
@@ -69,14 +69,20 @@ setup(
         'invenio_search.mappings': [
             'records = cd2h_repo_project.modules.records.mappings'
         ],
+        # Loaded when create_ui/create_app is used as application factory
         'invenio_base.apps': [
             'cd2hrepo_records = cd2h_repo_project.modules.records.ext:Records',
+            'cd2hrepo_doi = cd2h_repo_project.modules.doi.ext:DigitalObjectIdentifier',
+        ],
+        # Loaded when create_api/create_app is used as application factory
+        'invenio_base.api_apps': [
+            'cd2hrepo_doi = cd2h_repo_project.modules.doi.ext:DigitalObjectIdentifier',
         ],
         'invenio_access.actions': [
           'cd2h-edit-metadata = cd2h_repo_project.modules.records.permissions:cd2h_edit_metadata',
         ],
         'invenio_pidstore.minters': [
-            'cd2h_recid = cd2h_repo_project.modules.records.minters:mint_record',
+            'cd2h_recid = cd2h_repo_project.modules.records.minters:mint_pids_for_record',
         ],
     },
     classifiers=[

--- a/tests/api/doi/test_tasks.py
+++ b/tests/api/doi/test_tasks.py
@@ -3,47 +3,49 @@
 import json
 
 import datacite
-import pytest
+from elasticsearch.exceptions import RequestError
 from flask import url_for
 from invenio_pidstore.models import PersistentIdentifier, PIDStatus
-from invenio_records_files.api import Record
 
 from cd2h_repo_project.modules.doi.serializers import datacite_v41
 from cd2h_repo_project.modules.doi.tasks import register_doi
-from cd2h_repo_project.modules.records.minters import mint_record
+from cd2h_repo_project.modules.records.api import Deposit
+from cd2h_repo_project.modules.records.minters import mint_pids_for_record
 from cd2h_repo_project.modules.records.resolvers import record_resolver
 from utils import login_request_and_session
 
 
 def test_register_doi_task_is_triggered_on_publish(
         config, create_record, mocker):
-    orig_signal_trigger = config['DOI_REGISTER_SIGNALS']
+    original_doi_register_signals = config['DOI_REGISTER_SIGNALS']
     config['DOI_REGISTER_SIGNALS'] = True
     deposit = create_record(published=False)
     patched_delay = mocker.patch(
-        'cd2h_repo_project.modules.records.api.register_doi.delay')
+        'cd2h_repo_project.modules.doi.triggers.register_doi.delay')
 
     deposit.publish()
 
     assert patched_delay.called
 
-    config['DOI_REGISTER_SIGNALS'] = orig_signal_trigger
+    config['DOI_REGISTER_SIGNALS'] = original_doi_register_signals
 
 
-def test_register_doi_task_calls_succeeds(config, create_record, mocker):
+# TODO: Split this up in multiple tests
+def test_register_doi_task_succeeds(config, create_record, mocker):
     """Test successful doi task."""
+    original_datacite_doi_prefix = config['PIDSTORE_DATACITE_DOI_PREFIX']
+    config['PIDSTORE_DATACITE_DOI_PREFIX'] = '10.5072'
+    original_doi_register_signals = config['DOI_REGISTER_SIGNALS']
+    config['DOI_REGISTER_SIGNALS'] = False  # To be sure
     patched_client = mocker.patch(
         'cd2h_repo_project.modules.doi.tasks.DataCiteMDSClient')()
-    orig_pidstore_datacite_doi_prefix = config['PIDSTORE_DATACITE_DOI_PREFIX']
-    config['PIDSTORE_DATACITE_DOI_PREFIX'] = '10.5072'
     returned_doi = '10.5072/qwer-tyui'
     patched_client.metadata_post.return_value = 'OK ({})'.format(returned_doi)
     patched_indexer = mocker.patch(
         'cd2h_repo_project.modules.doi.tasks.RecordIndexer')()
-    # Because publish() triggers the task, we need to perform some of the steps
-    # of publish() without calling publish()
-    record = create_record(published=False)
-    mint_record(record.id, record)
+    # NOTE: `create_record` does NOT trigger register_doi bc
+    #       DOI_REGISTER_SIGNALS set to False
+    record = create_record()
     doi_pid = PersistentIdentifier.get(pid_type='doi', pid_value=record['id'])
 
     register_doi(record['id'])
@@ -56,18 +58,19 @@ def test_register_doi_task_calls_succeeds(config, create_record, mocker):
         returned_doi,
         'https://localhost:5000/records/{}'.format(record['id'])
     )
-
     # Validate DOI update
     doi_pid = PersistentIdentifier.get(pid_type='doi', pid_value=returned_doi)
-    assert doi_pid.pid_value == returned_doi
-    pid, record = record_resolver.resolve(str(record['id']))
+    assert doi_pid
+    recid_pid, record = record_resolver.resolve(str(record['id']))
+    depid_pid, deposit = Deposit.fetch_deposit(record)
+    assert deposit['doi'] == returned_doi
     assert record['doi'] == returned_doi
-    assert doi_pid.status == PIDStatus.REGISTERED
-
+    assert doi_pid.is_registered() and not doi_pid.is_new()
     # Validate indexing
     assert patched_indexer.index.called
 
-    config['PIDSTORE_DATACITE_DOI_PREFIX'] = orig_pidstore_datacite_doi_prefix
+    config['PIDSTORE_DATACITE_DOI_PREFIX'] = original_datacite_doi_prefix
+    config['DOI_REGISTER_SIGNALS'] = original_doi_register_signals
 
 
 def test_register_doi_task_retries_if_datacite_down(create_record, mocker):
@@ -80,11 +83,10 @@ def test_register_doi_task_retries_if_datacite_down(create_record, mocker):
         'cd2h_repo_project.modules.doi.tasks.DataCiteMDSClient')()
     patched_retry = mocker.patch(
         'cd2h_repo_project.modules.doi.tasks.register_doi.retry')
-
     # Because publish() triggers the task, we need to perform some of the steps
     # of publish() without calling publish()
     record = create_record(published=False)
-    mint_record(record.id, record)
+    mint_pids_for_record(record.id, record)
     doi_pid = PersistentIdentifier.get(pid_type='doi', pid_value=record['id'])
 
     # Test HttpError
@@ -104,23 +106,22 @@ def test_register_doi_task_retries_if_datacite_down(create_record, mocker):
     assert number_retries == 2
 
 
-def test_register_doi_task_doesnt_retry_if_other_error(create_record, mocker):
+def test_register_doi_task_doesnt_retry_if_indexing_error(
+        create_record, mocker):
     """Test failing register_doi task because of us."""
     patched_client = mocker.patch(
         'cd2h_repo_project.modules.doi.tasks.DataCiteMDSClient')()
     patched_retry = mocker.patch(
         'cd2h_repo_project.modules.doi.tasks.register_doi.retry')
-
     # Because publish() triggers the task, we need to perform some of the steps
     # of publish() without calling publish()
     record = create_record(published=False)
-    mint_record(record.id, record)
+    mint_pids_for_record(record.id, record)
     doi_pid = PersistentIdentifier.get(pid_type='doi', pid_value=record['id'])
 
-    patched_client.metadata_post.side_effect = Exception()
+    patched_client.metadata_post.side_effect = RequestError()
 
-    with pytest.raises(Exception):
-        register_doi(record['id'])
+    register_doi(record['id'])
 
     number_retries = len(patched_retry.mock_calls)
     assert number_retries == 0
@@ -130,7 +131,7 @@ def test_register_doi_task_doesnt_retry_if_other_error(create_record, mocker):
 def test_register_doi_task_second_time_succeeds(config, create_record, mocker):
     patched_client = mocker.patch(
         'cd2h_repo_project.modules.doi.tasks.DataCiteMDSClient')()
-    orig_pidstore_datacite_doi_prefix = config['PIDSTORE_DATACITE_DOI_PREFIX']
+    original_datacite_doi_prefix = config['PIDSTORE_DATACITE_DOI_PREFIX']
     config['PIDSTORE_DATACITE_DOI_PREFIX'] = '10.5072'
     patched_client.metadata_post.return_value = 'OK (10.5072/qwer-tyui)'
     patched_indexer = mocker.patch(
@@ -138,7 +139,7 @@ def test_register_doi_task_second_time_succeeds(config, create_record, mocker):
     # Because publish() triggers the task, we need to perform some of the steps
     # of publish() without calling publish()
     record = create_record(published=False)
-    mint_record(record.id, record)
+    mint_pids_for_record(record.id, record)
     doi_pid = PersistentIdentifier.get(pid_type='doi', pid_value=record['id'])
 
     register_doi(record['id'])
@@ -147,4 +148,4 @@ def test_register_doi_task_second_time_succeeds(config, create_record, mocker):
     assert len(patched_client.metadata_post.mock_calls) == 2
     assert len(patched_client.doi_post.mock_calls) == 1
 
-    config['PIDSTORE_DATACITE_DOI_PREFIX'] = orig_pidstore_datacite_doi_prefix
+    config['PIDSTORE_DATACITE_DOI_PREFIX'] = original_datacite_doi_prefix

--- a/tests/api/records/test_minters.py
+++ b/tests/api/records/test_minters.py
@@ -3,17 +3,17 @@ import uuid
 import pytest
 from invenio_pidstore.models import PersistentIdentifier, PIDStatus
 
-from cd2h_repo_project.modules.records.minters import mint_record
+from cd2h_repo_project.modules.records.minters import mint_pids_for_record
 
 
-def test_mint_record_creates_recid_pid(config, db):
+def test_mint_pids_for_record_creates_recid_pid(config, db):
     rec_uuid = uuid.uuid4()
     data = {}
     assert (
         PersistentIdentifier.query.filter_by(pid_type='recid').first() is None
     )
 
-    mint_record(rec_uuid, data)
+    mint_pids_for_record(rec_uuid, data)
 
     recid_value = data[config['PIDSTORE_RECID_FIELD']]
     assert recid_value
@@ -22,15 +22,16 @@ def test_mint_record_creates_recid_pid(config, db):
     assert pid.status == PIDStatus.REGISTERED
 
 
-def test_mint_record_already_minted_recid_pid_raises_exception(config, db):
+def test_mint_pids_for_record_for_already_minted_recid_pid_raises_exception(
+        config, db):
     rec_uuid = uuid.uuid4()
     data = {config['PIDSTORE_RECID_FIELD']: 'a value'}
 
     with pytest.raises(AssertionError):
-        mint_record(rec_uuid, data)
+        mint_pids_for_record(rec_uuid, data)
 
 
-def test_mint_record_creates_doi_pid(config, db):
+def test_mint_pids_for_record_creates_doi_pid(config, db):
     recid_field = config['PIDSTORE_RECID_FIELD']
     rec_uuid = uuid.uuid4()
     data = {}
@@ -38,7 +39,7 @@ def test_mint_record_creates_doi_pid(config, db):
         PersistentIdentifier.query.filter_by(pid_type='doi').first() is None
     )
 
-    mint_record(rec_uuid, data)
+    mint_pids_for_record(rec_uuid, data)
 
     doi_value = data['doi']
     assert doi_value == ''
@@ -47,10 +48,11 @@ def test_mint_record_creates_doi_pid(config, db):
     assert pid.status == PIDStatus.NEW
 
 
-def test_mint_record_already_minted_doi_pid_raises_exception(config, db):
+def test_mint_pids_for_record_for_already_minted_doi_pid_raises_exception(
+        config, db):
     recid_field = config['PIDSTORE_RECID_FIELD']
     rec_uuid = uuid.uuid4()
     data = {'doi': 'a value'}
 
     with pytest.raises(AssertionError):
-        mint_record(rec_uuid, data)
+        mint_pids_for_record(rec_uuid, data)

--- a/tests/api/records/test_serializers.py
+++ b/tests/api/records/test_serializers.py
@@ -5,7 +5,7 @@ from flask import current_app
 from invenio_pidstore.models import PersistentIdentifier
 
 from cd2h_repo_project.modules.doi.serializers import datacite_v41
-from cd2h_repo_project.modules.records.minters import mint_record
+from cd2h_repo_project.modules.records.minters import mint_pids_for_record
 from cd2h_repo_project.modules.records.serializers import json_v1
 
 
@@ -51,7 +51,7 @@ class TestJsonV1(object):
 @pytest.fixture
 def serialized_record(create_record):
     record = create_record(published=False)
-    mint_record(record.id, record)
+    mint_pids_for_record(record.id, record)
     pid = PersistentIdentifier.get('doi', record['id'])
     return datacite_v41.serialize(pid, record)
 


### PR DESCRIPTION
- Main fix: pass record.revision_id to
  deposit at edit time
- Update all our Record references to
  records/api.py::Record
- Fix circular import via signal
- Rename mint_record -> mint_pids_for_record
- Update deposit in register_doi
- Close #267