### PR TITLE
 [#333] Make DOI 'findable' on DataCite if record not private 

### DIFF
--- a/cd2h_repo_project/modules/doi/views.py
+++ b/cd2h_repo_project/modules/doi/views.py
@@ -34,7 +34,7 @@ def to_doi_field(record):
         doi_url = doi_url_for(doi_value)
         return '<a href="{0}">{0}</a>'.format(doi_url)
     elif datetime.utcnow() < record.model.created + timedelta(hours=24):
-        return 'Minting the DOI...'
+        return 'Minting the DOI... (refresh to update)'
     else:
         return (
             'There was an issue minting the DOI. '

--- a/cd2h_repo_project/modules/records/permissions.py
+++ b/cd2h_repo_project/modules/records/permissions.py
@@ -142,6 +142,15 @@ class RecordPermissions(object):
         """
         return [cls.ALL_VIEW, cls.RESTRICTED_VIEW, cls.PRIVATE_VIEW]
 
+    @classmethod
+    def is_private(cls, record):
+        """Returns if record is private or not.
+
+        Abstracts away permissions implementation and defaults to private if
+        no permissions.
+        """
+        return record.get('permissions', 'private_').startswith('private_')
+
 
 class ViewPermission(object):
     """Gate to allow or not view of a record.

--- a/cd2h_repo_project/modules/records/templates/records/view.html
+++ b/cd2h_repo_project/modules/records/templates/records/view.html
@@ -111,6 +111,9 @@
 
           <dt>Digital Object Identifier (DOI)</dt>
           <dd>{{ record | to_doi_field | safe }}</dd>
+          {% if record | is_private %}
+          <dd class="metadata-help">If the record was never made public, this link will not resolve.</dd>
+          {% endif %}
 
           <dt>Resource Type</dt>
           <dd>{{ record.resource_type.general.title() }} / {{ record.resource_type.specific.title() }}</dd>

--- a/cd2h_repo_project/modules/records/views.py
+++ b/cd2h_repo_project/modules/records/views.py
@@ -17,7 +17,7 @@ from invenio_records_ui.signals import record_viewed
 from cd2h_repo_project.modules.records.links import deposit_links_ui_factory
 from cd2h_repo_project.modules.records.marshmallow.json import LICENSES
 from cd2h_repo_project.modules.records.permissions import (
-    EditMetadataPermission
+    EditMetadataPermission, RecordPermissions
 )
 
 blueprint = Blueprint(
@@ -152,3 +152,9 @@ def permissions_to_access_name(permissions):
         return 'Restricted Access'
     else:
         return 'Private Access'
+
+
+@blueprint.app_template_filter('is_private')
+def is_private(record):
+    """Return True/False corresponding to private or not."""
+    return RecordPermissions.is_private(record)

--- a/cd2h_repo_project/modules/theme/static/scss/recordpage.scss
+++ b/cd2h_repo_project/modules/theme/static/scss/recordpage.scss
@@ -1,12 +1,16 @@
-@import 'common';
 
+#metadata-section {
+  .dl-horizontal {
+    dt {
+      width: 215px;
+    }
 
-#metadata-section .dl-horizontal {
-  dt {
-    width: 215px;
+    dd {
+      margin-left: 235px;
+    }
   }
 
-  dd {
-    margin-left: 235px;
+  .metadata-help {
+    color: #737373;
   }
 }

--- a/tests/api/records/test_permissions.py
+++ b/tests/api/records/test_permissions.py
@@ -158,3 +158,15 @@ def test_view_permission_factory(
     permission = view_permission_factory(record)
 
     assert permission.can() == allowed
+
+
+@pytest.mark.parametrize(
+    'record, expected',
+    [
+        ({}, True),
+        ({'permissions': 'private_view'}, True),
+        ({'permissions': 'restricted_view'}, False),
+    ]
+)
+def test_is_private(record, expected):
+    assert RecordPermissions.is_private(record) is expected

--- a/tests/api/records/test_search.py
+++ b/tests/api/records/test_search.py
@@ -257,15 +257,15 @@ class TestRecordsSearch(object):
 
     def test_search_orders_by_bestmatch_desc_if_query_but_no_sort(
             self, client, create_record, es_clear):
-        record1 = create_record({"title": "old record"})
-        record2 = create_record({"title": "More recent record"})
+        record1 = create_record({"title": "record old record old record"})
+        record2 = create_record({"title": "record"})
 
         response = client.get("/records/?q=old+record")
 
         hit1 = response.json['hits']['hits'][0]
-        assert hit1['metadata']['title'] == "old record"
+        assert hit1['metadata']['title'] == "record old record old record"
         hit2 = response.json['hits']['hits'][1]
-        assert hit2['metadata']['title'] == "More recent record"
+        assert hit2['metadata']['title'] == "record"
 
     def test_search_returns_restricted_access_results_to_authenticated_user(
             self, client, create_record, create_user, es_clear):

--- a/tests/ui/doi/test_views.py
+++ b/tests/ui/doi/test_views.py
@@ -12,7 +12,7 @@ from cd2h_repo_project.modules.doi.views import to_doi_field
         ('<a href="https://doi.org/10.5072/qwer-tyui">'
          'https://doi.org/10.5072/qwer-tyui</a>')
     ),
-    ('', False, 'Minting the DOI...'),
+    ('', False, 'Minting the DOI... (refresh to update)'),
     (
         '',
         True,


### PR DESCRIPTION
- Don't assign landing page to private record (draft on DataCite)
- Add 'refresh to update' indication on DOI field
- Add help text to normalize the fact that a private DOI may not resolve
- Refactor some fixtures for test_tasks.py
- Fix search ordering heisen-bug through improved matching
 - Closes #333 
