### PR TITLE
[#405] Fix citation clipboard copy on stage

### DIFF
--- a/cd2h_repo_project/modules/records/bundles.py
+++ b/cd2h_repo_project/modules/records/bundles.py
@@ -33,6 +33,8 @@ js_search = Bundle(
 js_view = Bundle(
     NpmBundle(
         'node_modules/clipboard/dist/clipboard.js',
+        'js/view/record.js',
+        filters='requirejs',
         output="gen/cd2hrepo.view.clipboard.%(version)s.js",
         npm={
             'clipboard': '~2.0.4',

--- a/cd2h_repo_project/modules/records/static/js/view/record.js
+++ b/cd2h_repo_project/modules/records/static/js/view/record.js
@@ -1,0 +1,8 @@
+const ClipboardJS = require("node_modules/clipboard/dist/clipboard")
+
+const clip = new ClipboardJS('.clipboard-btn');
+const $tooltip = $('[data-toggle="tooltip"]');
+$tooltip.tooltip();  // Initializes tooltips
+$tooltip.on('show.bs.tooltip', () => {
+  $('.tooltip').not(this).remove();
+});

--- a/cd2h_repo_project/modules/records/templates/records/view.html
+++ b/cd2h_repo_project/modules/records/templates/records/view.html
@@ -194,14 +194,6 @@
 {% endblock content %}
 
 {% block javascript %}
-  {% assets "cd2hrepo_view_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
   {{ super() }}
-  <script type="text/javascript">
-    const clip = new ClipboardJS('.clipboard-btn');
-    const $tooltip = $('[data-toggle="tooltip"]');
-    $tooltip.tooltip();  // Initializes tooltips
-    $tooltip.on('show.bs.tooltip', () => {
-      $('.tooltip').not(this).remove();
-    });
-  </script>
+  {% assets "cd2hrepo_view_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
 {% endblock %}


### PR DESCRIPTION
<script> tags with content can't be used directly because of security-policies in place.
Any JS must be bundled.